### PR TITLE
Updated readme and added readme example code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed README code example
+
 ## [0.3.0]
 
 ### Changed

--- a/Readme.md
+++ b/Readme.md
@@ -4,16 +4,20 @@ Parses strings that express dates in a human way into ones usable by code.
 
 ## Usage
 
-Using it is as simple as calling `from_human_time` with a string slice. Like this:
+Using it is as simple as calling `from_human_time` with a string slice and the current date and time. Like this:
 
 ```rust
 use human_date_parser::from_human_time;
+use chrono::Local;
 
 fn main() {
-    let date = from_human_time("Last Friday at 19:45").unwrap();
+    let now = Local::now().naive_local();
+    let date = from_human_time("Last Friday at 19:45", now).unwrap();
     println!("{date}");
 }
 ```
+
+The date and time doesn't have to be 'now' specifically. It's used to figure out what a relative statement like "Next Monday" would actually mean, given the date.
 
 You can also use the example to try out a few dates and see what it can and can't parse. Simply run `cargo run --example stdin`.
 

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -1,0 +1,9 @@
+// The example from the README
+use human_date_parser::from_human_time;
+use chrono::Local;
+
+fn main() {
+    let now = Local::now().naive_local();
+    let date = from_human_time("Last Friday at 19:45", now).unwrap();
+    println!("{date}");
+}


### PR DESCRIPTION
The readme example should always reflect the code in the readme file. That way it's easier to see if a change breaks the example.